### PR TITLE
Allow featured items to be draggable in the preview

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -2,6 +2,7 @@
 	margin-top: 1em;
 	margin-bottom: 1em;
 	display: flex;
+	position: relative; /* For sake of sortable items. */
 }
 .featured-content-item {
 	margin-left: 1em;

--- a/css/preview.css
+++ b/css/preview.css
@@ -1,0 +1,3 @@
+.featured-content-item.ui-sortable-helper a {
+	cursor: move;
+}

--- a/js/preview.js
+++ b/js/preview.js
@@ -1,6 +1,6 @@
 /* global wp */
 
-wp.customize.featuredContent.preview = (function( api ) {
+wp.customize.featuredContent.preview = (function( api, $ ) {
 	'use strict';
 
 	var component = {
@@ -32,6 +32,8 @@ wp.customize.featuredContent.preview = (function( api ) {
 		api.preview.bind( 'featured-item-untrashed', function( id ) {
 			component.ensurePartial( id ).refresh();
 		} );
+
+		component.enableDraggableItemPositioning();
 	};
 
 	/**
@@ -51,6 +53,31 @@ wp.customize.featuredContent.preview = (function( api ) {
 			api.selectiveRefresh.partial.add( partial.id, partial );
 		}
 		return partial;
+	};
+
+	/**
+	 * Allow featured items to be re-positioned by drag-and-drop inside the preview.
+	 *
+	 * @returns {void}
+	 */
+	component.enableDraggableItemPositioning = function enableDraggableItemPositioning() {
+		$( '.featured-content-items' ).each( function() {
+			var container = $( this );
+
+			container.sortable({
+				items: '> .featured-content-item[data-customize-partial-id]',
+				axis: 'x',
+				tolerance: 'pointer',
+				stop: function() {
+					container.find( '> .featured-content-item[data-customize-partial-id]' ).each( function( i ) {
+						var partialId, positionSettingId;
+						partialId = $( this ).data( 'customize-partial-id' );
+						positionSettingId = partialId + '[position]';
+						api.preview.send( 'setting', [ positionSettingId, i ] );
+					} );
+				}
+			});
+		} );
 	};
 
 	return component;

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -209,6 +209,7 @@ class Plugin {
 			'customize-featured-items-wp-api-extensions',
 			'customize-selective-refresh',
 			'customize-featured-item-property-inline-editing',
+			'jquery-ui-sortable',
 		);
 		$wp_scripts->add( $handle, $src, $deps, $this->version );
 


### PR DESCRIPTION
In addition to being able to re-position items by dragging their section in the pane, this allows you to use direct manipulation to re-order the items in the preview via drag-and-drop.

Demo video: https://youtu.be/_8Est2HYWdk